### PR TITLE
fix: Adapta o Makefile para fazer build do diretório do app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,11 @@ endif
 
 .PHONY: build
 build:
-	docker build --platform $(PLATFORM) --tag $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) \
-		-f app/Dockerfile .
+	cd app && docker build --platform $(PLATFORM) --tag $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) .
 
 .PHONY: build-multi-arch
 build-multi-arch:
-	docker buildx build --platform linux/amd64,linux/arm64 --tag $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) \
-		-f app/Dockerfile .
+	cd app && docker buildx build --platform linux/amd64,linux/arm64 --tag $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) .
 
 .PHONY: login
 login:


### PR DESCRIPTION
O Dockerfile e o código fonte que vai para dentro da imagem estão todos dentro do diretório "app", mas o Makefile está fora.

Dessa forma, o Makefile estava criando um problema de contexto ao executar o build usando um contexto diferente para o Dockerfile.
Ao forçar entrar no diretório antes de executar o docker build, garantimos o contexto correto para que o Docker acesse o que é necessário.