### PR TITLE
feat: Adiciona endpoint de Healthcheck

### DIFF
--- a/app/config/health.py
+++ b/app/config/health.py
@@ -1,0 +1,20 @@
+"""
+Health check views for the Querido Diário Backend.
+"""
+from django.http import JsonResponse
+from django.views import View
+
+
+class HealthCheckView(View):
+    """
+    Health check endpoint for monitoring and load balancers.
+    Returns 200 OK when the service is healthy.
+    """
+    
+    def get(self, request, *args, **kwargs):
+        """Handle GET requests to the health endpoint."""
+        return JsonResponse({
+            "status": "healthy",
+            "service": "querido-diario-backend",
+            "django_version": "4.0.3"
+        })

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -5,8 +5,10 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
     TokenVerifyView,
 )
+from .health import HealthCheckView
 
 urlpatterns = [
+    path("health/", HealthCheckView.as_view(), name="health_check"),
     path("api/admin/", admin.site.urls),
     path("api/accounts/", include("accounts.urls")),
     path("api/reports/", include("reports.urls")),


### PR DESCRIPTION
Isso é importante para rodar o healthcheck do container quando iniciamos a aplicação em produção - e para mantê-la sendo verificada constantemente.