### PR TITLE
docs: move community files from docs/ to repository root

### DIFF
--- a/CODE_OF_CONDUCT-en-US.md
+++ b/CODE_OF_CONDUCT-en-US.md
@@ -1,4 +1,4 @@
-**English (US)** | [Português (BR)](/docs/CODE_OF_CONDUCT.md)
+**English (US)** | [Português (BR)](/CODE_OF_CONDUCT.md)
 
 # Contributor Covenant Code of Conduct
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-**Português (BR)** | [English (US)](/docs/CODE_OF_CONDUCT-en-US.md)
+**Português (BR)** | [English (US)](/CODE_OF_CONDUCT-en-US.md)
 
 # Código de Conduta de Colaboração
 

--- a/SUPPORT-en-US.md
+++ b/SUPPORT-en-US.md
@@ -1,4 +1,4 @@
-**English (US)** | [Português (BR)](/docs/SUPPORT.md)
+**English (US)** | [Português (BR)](/SUPPORT.md)
 
 # Support
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,4 +1,4 @@
-**Português (BR)** | [English (US)](/docs/SUPPORT-en-US.md)
+**Português (BR)** | [English (US)](/SUPPORT-en-US.md)
 
 # Suporte
 


### PR DESCRIPTION
Moves CODE_OF_CONDUCT.md, CODE_OF_CONDUCT-en-US.md, SUPPORT.md and SUPPORT-en-US.md from docs/ to the root so GitHub automatically recognizes them as community health files.

Updates internal cross-language links in all four files to reflect the new paths.

Closes #49