### PR TITLE
docs: move CONTRIBUTING.md files to repository root and fix internal links

### DIFF
--- a/CONTRIBUTING-en-US.md
+++ b/CONTRIBUTING-en-US.md
@@ -1,4 +1,4 @@
-**English (US)** | [Português (BR)](/docs/CONTRIBUTING.md)
+**English (US)** | [Português (BR)](/CONTRIBUTING.md)
 
 # Contributing
 Querido Diario has a [Contribution Guide](https://docs.queridodiario.ok.org.br/en/latest/contributing/contribution-guide.html#contributing) that is relevant to all of its repositories. The guide provides general information about how to interact with the project, the code of conduct you adhere to when contributing, the list of ecosystem repositories and the first actions you can take. We recommend reading it before continuing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-**Português (BR)** | [English (US)](/docs/CONTRIBUTING-en-US.md)
+**Português (BR)** | [English (US)](/CONTRIBUTING-en-US.md)
 
 # Contribuindo
 O Querido Diário possui um [Guia para Contribuição](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/guia-de-contribuicao.html#contribuindo) principal que é relevante para todos os seus repositórios. Este guia traz informações gerais sobre como interagir com o projeto, o código de conduta que você adere ao contribuir, a lista de repositórios do ecossistema e as primeiras ações que você pode tomar. Recomendamos sua leitura antes de continuar.


### PR DESCRIPTION
Moves CONTRIBUTING.md and CONTRIBUTING-en-US.md from docs/ to root so GitHub automatically recognizes them as community health files. Updates internal cross-language links. Content still needs to be completed.

Related to #48